### PR TITLE
Updated for Orleans 1.0.0; new config options; other enhancements

### DIFF
--- a/Orleans.StorageProvider.Blob.Test.GrainClasses/Orleans.StorageProvider.Blob.Test.GrainClasses.csproj
+++ b/Orleans.StorageProvider.Blob.Test.GrainClasses/Orleans.StorageProvider.Blob.Test.GrainClasses.csproj
@@ -36,6 +36,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Orleans">
+      <HintPath>$(OrleansSDK)\Binaries\OrleansServer\Orleans.dll</HintPath>
+    </Reference>
+    <Reference Include="OrleansRuntime">
+      <HintPath>$(OrleansSDK)\Binaries\OrleansServer\OrleansRuntime.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -43,10 +49,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Orleans">
-      <HintPath>$(OrleansSDK)\Binaries\OrleansClient\Orleans.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Grain1.cs" />

--- a/Orleans.StorageProvider.Blob.Test.GrainInterfaces/Orleans.StorageProvider.Blob.Test.GrainInterfaces.csproj
+++ b/Orleans.StorageProvider.Blob.Test.GrainInterfaces/Orleans.StorageProvider.Blob.Test.GrainInterfaces.csproj
@@ -31,8 +31,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="OrleansProviderInterfaces">
-      <HintPath>..\..\..\..\..\..\Microsoft Codename Orleans SDK v0.9\SDK\Binaries\OrleansServer\OrleansProviderInterfaces.dll</HintPath>
+    <Reference Include="Orleans">
+      <HintPath>$(OrleansSDK)\Binaries\OrleansServer\Orleans.dll</HintPath>
+    </Reference>
+    <Reference Include="OrleansProviders">
+      <HintPath>$(OrleansSDK)\Binaries\OrleansServer\OrleansProviders.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -41,10 +44,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Orleans">
-      <HintPath>$(OrleansSDK)\Binaries\OrleansClient\Orleans.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="IGrain1.cs" />

--- a/Orleans.StorageProvider.Blob.Tests/Orleans.StorageProvider.Blob.Tests.csproj
+++ b/Orleans.StorageProvider.Blob.Tests/Orleans.StorageProvider.Blob.Tests.csproj
@@ -36,16 +36,19 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Orleans">
-      <HintPath>..\..\..\..\..\..\Microsoft Codename Orleans SDK v0.9\SDK\Binaries\OrleansServer\Orleans.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>$(OrleansSDK)\Binaries\OrleansServer\Orleans.dll</HintPath>
     </Reference>
-    <Reference Include="OrleansProviderInterfaces">
-      <HintPath>..\..\..\..\..\..\Microsoft Codename Orleans SDK v0.9\SDK\Binaries\OrleansServer\OrleansProviderInterfaces.dll</HintPath>
+    <Reference Include="OrleansAzureUtils">
+      <HintPath>$(OrleansSDK)\Binaries\OrleansServer\OrleansAzureUtils.dll</HintPath>
     </Reference>
     <Reference Include="OrleansProviders">
-      <HintPath>..\..\..\..\..\..\Microsoft Codename Orleans SDK v0.9\SDK\Binaries\OrleansServer\OrleansProviders.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>$(OrleansSDK)\Binaries\OrleansServer\OrleansProviders.dll</HintPath>
     </Reference>
     <Reference Include="OrleansRuntime">
-      <HintPath>..\..\..\..\..\..\Microsoft Codename Orleans SDK v0.9\SDK\Binaries\OrleansServer\OrleansRuntime.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>$(OrleansSDK)\Binaries\OrleansServer\OrleansRuntime.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/Orleans.StorageProvider.Blob.Tests/UnitTest1.cs
+++ b/Orleans.StorageProvider.Blob.Tests/UnitTest1.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading.Tasks;
-using Orleans.Host;
+using Orleans.Runtime.Host;
 using System.Diagnostics;
 using Orleans.StorageProvider.Blob.Test.GrainInterfaces;
 
@@ -30,17 +30,17 @@ namespace Orleans.StorageProvider.Blob.Tests
 
         // code to initialize and clean up an Orleans Silo
 
-        static OrleansSiloHost siloHost;
+        static SiloHost siloHost;
         static AppDomain hostDomain;
 
         static void InitSilo(string[] args)
         {
-            siloHost = new OrleansSiloHost("Primary");
+            siloHost = new SiloHost("Primary");
             siloHost.ConfigFileName = "DevTestServerConfiguration.xml";
             siloHost.DeploymentId = "1";
             siloHost.InitializeOrleansSilo();
             var ok = siloHost.StartOrleansSilo();
-            if (!ok) throw new SystemException(string.Format("Failed to start Orleans silo '{0}' as a {1} node.", siloHost.SiloName, siloHost.SiloType));
+            if (!ok) throw new SystemException(string.Format("Failed to start Orleans silo '{0}' as a {1} node.", siloHost.Name, siloHost.Type));
         }
 
         [ClassInitialize]
@@ -53,7 +53,7 @@ namespace Orleans.StorageProvider.Blob.Tests
                 ApplicationBase = AppDomain.CurrentDomain.SetupInformation.ApplicationBase,
             });
 
-            Orleans.OrleansClient.Initialize("DevTestClientConfiguration.xml");
+            GrainClient.Initialize("DevTestClientConfiguration.xml");
         }
 
         [ClassCleanup]

--- a/Orleans.StorageProvider.Blob/Orleans.StorageProvider.Blob.csproj
+++ b/Orleans.StorageProvider.Blob/Orleans.StorageProvider.Blob.csproj
@@ -30,50 +30,54 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Data.Edm, Version=5.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Data.Edm.5.6.1\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Data.Edm.5.6.3\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Data.OData, Version=5.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Data.OData.5.6.1\lib\net40\Microsoft.Data.OData.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Data.OData.5.6.3\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.1\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.3\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\WindowsAzure.Storage.4.1.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <HintPath>..\packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Orleans">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>$(OrleansSDK)\Binaries\OrleansServer\Orleans.dll</HintPath>
     </Reference>
-    <Reference Include="Orleans.Serialization.Newtonsoft.Json">
-      <HintPath>..\packages\Orleans.Serialization.Newtonsoft.Json.0.9.0\lib\net45\Orleans.Serialization.Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Orleans.Serialization.Newtonsoft.Json, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\orleans.serialization.json\Orleans.Serialization.Newtonsoft.Json\bin\Debug\Orleans.Serialization.Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="OrleansProviderInterfaces">
-      <HintPath>$(OrleansSDK)\Binaries\OrleansServer\OrleansProviderInterfaces.dll</HintPath>
+    <Reference Include="OrleansAzureUtils">
+      <HintPath>$(OrleansSDK)\Binaries\OrleansServer\OrleansAzureUtils.dll</HintPath>
     </Reference>
     <Reference Include="OrleansProviders">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>$(OrleansSDK)\Binaries\OrleansServer\OrleansProviders.dll</HintPath>
     </Reference>
     <Reference Include="OrleansRuntime">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>$(OrleansSDK)\Binaries\OrleansServer\OrleansRuntime.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Spatial, Version=5.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Spatial, Version=5.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.Spatial.5.6.1\lib\net40\System.Spatial.dll</HintPath>
+      <HintPath>..\packages\System.Spatial.5.6.3\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
@@ -84,7 +88,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Orleans.StorageProvider.Blob/packages.config
+++ b/Orleans.StorageProvider.Blob/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Data.Edm" version="5.6.1" targetFramework="net45" />
-  <package id="Microsoft.Data.OData" version="5.6.1" targetFramework="net45" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.1" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.6.3" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.3" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.3" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="Orleans.Serialization.Newtonsoft.Json" version="0.9.0" targetFramework="net45" />
-  <package id="System.Spatial" version="5.6.1" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="4.1.0" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.3" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
## Updated for Orleans 1.0.0; updated for latest NuGet versions; enhancements in ReadStateAsync() and WriteStateAsync() to specify IDictionary<string, object> for clarity; added three configuration options to control serialization options.

Richard -

I've made a bunch of updates here, some I'd argue are bug fixes, some are enhancements... here's what I've done:

* Update references to Orleans 1.0.0, including a few class name changes
* Added a providerRuntime.GetLogger() call to match the new 1.0.0 API
* Specifically updated ReadStateAsync() to deserialize into an IDictionary<string, object>, since that's what WriteStateAsync() actually serializes from (this was a bug on deserialization I was running into).
* Added a line of verbose logging in WriteStateAsync()
* Updated NuGet packages to latest versions
* Added a sanity check error condition if DataConnectionString isn't provided
* Added three boolean configuration options; __all of these options have the same default values as before__, so existing code will not break
  * __SerializeTypeNames__: this will add the type names to the serialized data; I need this because I serialize DerivedEvents from a List<Event> (Event = base class) and I need to be able to recover the derived types on deserialization
  * __UseFullAssemblyNames__: this will keep strong-named assembly versions in the serialized data, meaning that the data must be deserialized with the same version of code
  * __IndentJSON__: this writes the serialized data out with indenting and formatting... easier to debug with.

I think that's it. It's a fair bit of change... happy to handle it however you'd like. If you take these changes, I'll follow up with a wiki page that explains the configuration options.

Thanks!
Scott
Seattle, WA, USA