### PR TITLE
Set blob ContentType to "application/json" in WriteStateAsync().

### DIFF
--- a/Orleans.StorageProvider.Blob/BlobStorageProvider.cs
+++ b/Orleans.StorageProvider.Blob/BlobStorageProvider.cs
@@ -142,6 +142,7 @@ namespace Orleans.StorageProvider.Blob
                 Log.Verbose("Serialized grain state is: {0}.", storedData);
 
                 var blob = container.GetBlockBlobReference(blobName);
+                blob.Properties.ContentType = "application/json";
                 await
                     blob.UploadTextAsync(
                         storedData,


### PR DESCRIPTION
This is more of a _this is technically correct_ change than a necessary, functional one. We definitely are serializing to JSON, so the blob contents are technically an "application/json" type (see http://www.ietf.org/rfc/rfc4627.txt). I'm proposing this change primarily to help third-party tools automatically identify the content-type properly, and just because it's the right thing to do. I can't think of anything that this code change would break for any existing code or stored data.

With that said, if anyone can think of a reason not to take this change, I'm open to hearing why.

Thanks!
Scott